### PR TITLE
fix: made best_fitness to work with negative values

### DIFF
--- a/tfne/algorithms/codeepneat/codeepneat.py
+++ b/tfne/algorithms/codeepneat/codeepneat.py
@@ -101,7 +101,7 @@ class CoDeepNEAT(BaseNeuroevolutionAlgorithm,
 
         # Set internal variables of the population to the initialization of a new population
         self.pop.generation_counter = 0
-        self.pop.best_fitness = 0
+        self.pop.best_fitness = None
 
         #### Initialize Module Population ####
         # Initialize module population with a basic speciation scheme, even when another speciation type is supplied


### PR DESCRIPTION
This request is to fix issue #11. The current version codeepNEAT will not work for the negative fitness values cause it's base fitness value is set to 0. I have changed it to none to work for negative fitness values.